### PR TITLE
Add a flag for setting the timeout

### DIFF
--- a/surfer.go
+++ b/surfer.go
@@ -35,7 +35,7 @@ import (
 
 var (
 	port         = flag.Int("port", 6666, "port to listen on when serving prometheus metrics")
-	timeout      = flag.Duration("timeout", 1*time.Second, "timeout for HTTP get to cable modem")
+	timeout      = flag.Duration("timeout", 1*time.Second, "timeout for the HTTP GET to cable modem")
 	fakeDataPath = flag.String("fake", "", "path to fake HTML data.  (default) fetch over HTTP")
 
 	downstreamSNRMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/surfer.go
+++ b/surfer.go
@@ -130,7 +130,7 @@ func main() {
 	http.Handle("/metrics", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Only make one query to the cable modem if concurrent requests come in.
 		if _, err := g.Do("get", func() (interface{}, error) {
-			ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+			ctx, cancel := context.WithTimeout(ctx, *timeout)
 			defer cancel()
 			s, err := m.Status(ctx)
 			if err != nil {

--- a/surfer.go
+++ b/surfer.go
@@ -35,6 +35,7 @@ import (
 
 var (
 	port         = flag.Int("port", 6666, "port to listen on when serving prometheus metrics")
+	timeout      = flag.Duration("timeout", 1*time.Second, "timeout for HTTP get to cable modem")
 	fakeDataPath = flag.String("fake", "", "path to fake HTML data.  (default) fetch over HTTP")
 
 	downstreamSNRMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -112,7 +113,7 @@ func main() {
 	ctx := context.Background()
 	var m modem.Modem
 	for {
-		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, *timeout)
 		m = modem.New(ctx, *fakeDataPath)
 		cancel()
 		if m != nil {


### PR DESCRIPTION
I want the ability to specify a timeout for retrieving cable modem stats instead of the default 1s. I'm not sure why my cablem modem takes 10-30s to return a status page but until I figure that out, this lets me monitor the other stats I care abote.