### PR TITLE
Add ability to detect and scrape the SB8200 modem

### DIFF
--- a/modem/sb8200/sb8200.go
+++ b/modem/sb8200/sb8200.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2020 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ func New() modem.Modem {
 	return &sb8200{}
 }
 
-// NewFakeData returns a modem.Modem that with parse SB8200 formatted data
+// NewFakeData returns a modem.Modem that will parse SB8200 formatted data
 // from the HTML file given in path.
 func NewFakeData(path string) (modem.Modem, error) {
 	b, err := ioutil.ReadFile(path)

--- a/modem/sb8200/sb8200.go
+++ b/modem/sb8200/sb8200.go
@@ -1,0 +1,247 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sb8200 scrapes status from the Motorola/ARRIS SB8200.
+package sb8200
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/andybalholm/cascadia"
+	"github.com/golang/glog"
+	"golang.org/x/net/html"
+
+	"github.com/wathiede/surfer/htmlutil"
+	"github.com/wathiede/surfer/modem"
+)
+
+const signalURL = "http://192.168.100.1/cmconnectionstatus.html"
+
+type sb8200 struct {
+	fakeData []byte
+}
+
+func (sb8200) Name() string { return "SB8200" }
+
+func isSB8200(b []byte) bool {
+	return bytes.Contains(b, []byte(`<span id="thisModelNumberIs">SB8200</span>`))
+}
+
+func probe(ctx context.Context, path string) modem.Modem {
+	if path != "" {
+		b, err := ioutil.ReadFile(path)
+		if err != nil {
+			glog.Errorf("Failed to read %q: %v", path, err)
+			return nil
+		}
+		if isSB8200(b) {
+			m, err := NewFakeData(path)
+			if err != nil {
+				glog.Errorf("Failed to create fake SB8200: %v", err)
+				return nil
+			}
+			return m
+		}
+		return nil
+	}
+	glog.Infof("Probing %q", signalURL)
+	rc, err := get(ctx)
+	if err != nil {
+		glog.Errorf("Failed to get status page: %v", err)
+		return nil
+	}
+	defer rc.Close()
+	b, err := ioutil.ReadAll(io.LimitReader(rc, 1<<20))
+	if err != nil {
+		glog.Errorf("Failed to read status page: %v", err)
+		return nil
+	}
+	if isSB8200(b) {
+		return New()
+	}
+	return nil
+}
+
+func init() {
+	modem.Register(probe)
+}
+
+// New returns a modem.Modem that scrapes SB8200 formatted data at the default
+// URL.
+func New() modem.Modem {
+	return &sb8200{}
+}
+
+// NewFakeData returns a modem.Modem that with parse SB8200 formatted data
+// from the HTML file given in path.
+func NewFakeData(path string) (modem.Modem, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return &sb8200{fakeData: b}, nil
+}
+
+func get(ctx context.Context) (io.ReadCloser, error) {
+	req, err := http.NewRequest("GET", signalURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}
+
+// Status will return signal data parsed from an HTML status page.  If
+// sb.fakeData is not nil, the fake data is parsed.  If it is nil, then an
+// HTTP request is made to the default signal URL of a SB8200.
+func (sb *sb8200) Status(ctx context.Context) (*modem.Signal, error) {
+	if sb.fakeData != nil {
+		return parseStatus(bytes.NewReader(sb.fakeData))
+	}
+
+	rc, err := get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	return parseStatus(rc)
+}
+
+func parseStatus(r io.Reader) (*modem.Signal, error) {
+	n, err := html.Parse(r)
+	if err != nil {
+		return nil, err
+	}
+	tables := cascadia.MustCompile(".simpleTable").MatchAll(n)
+	if len(tables) != 3 {
+		return nil, fmt.Errorf("Found %d simpleTables, expected 3", len(tables))
+	}
+	d, err := parseDownstreamTable(tables[1])
+	if err != nil {
+		return nil, err
+	}
+	u, err := parseUpstreamTable(tables[2])
+	if err != nil {
+		return nil, err
+	}
+	return &modem.Signal{
+		Downstream: d,
+		Upstream:   u,
+	}, nil
+}
+
+func parseDownstreamTable(n *html.Node) (map[modem.Channel]*modem.Downstream, error) {
+	m := map[modem.Channel]*modem.Downstream{}
+	rows := cascadia.MustCompile("tr").MatchAll(n)
+	if len(rows) <= 2 {
+		return nil, fmt.Errorf("Expected more than 2 rows in table, got %d", len(rows))
+	}
+	for _, row := range rows[2:] {
+		d := &modem.Downstream{}
+		var ch modem.Channel
+		for i, col := range cascadia.MustCompile("td").MatchAll(row) {
+			v := htmlutil.GetText(col)
+			fv := v
+			if idx := strings.Index(v, " "); idx != -1 {
+				fv = fv[:idx]
+			}
+			f, _ := strconv.ParseFloat(fv, 64)
+			switch i {
+			case 0:
+				// Channel
+				ch = modem.Channel(v)
+			case 1:
+				// Lock Status
+			case 2:
+				// Modulation
+				d.Modulation = v
+			case 3:
+				// Frequency (Hz)
+				d.Frequency = v
+			case 4:
+				// Power (dBmV)
+				d.PowerLevel = f
+			case 5:
+				// SNR (dB)
+				d.SNR = f
+			case 6:
+				// Corrected
+				d.Correctable = f
+			case 7:
+				// Uncorrectables
+				d.Uncorrectable = f
+			default:
+				glog.Errorf("Unexpected %dth column in downstream table", i)
+			}
+		}
+		m[ch] = d
+	}
+	return m, nil
+}
+
+func parseUpstreamTable(n *html.Node) (map[modem.Channel]*modem.Upstream, error) {
+	m := map[modem.Channel]*modem.Upstream{}
+	rows := cascadia.MustCompile("tr").MatchAll(n)
+	if len(rows) <= 2 {
+		return nil, fmt.Errorf("Expected more than 2 row in table, got %d", len(rows))
+	}
+	for _, row := range rows[2:] {
+		u := &modem.Upstream{}
+		var ch modem.Channel
+		for i, col := range cascadia.MustCompile("td").MatchAll(row) {
+			v := htmlutil.GetText(col)
+			fv := v
+			if idx := strings.Index(v, " "); idx != -1 {
+				fv = fv[:idx]
+			}
+			f, _ := strconv.ParseFloat(fv, 64)
+			switch i {
+			case 0:
+				// Channel
+				ch = modem.Channel(v)
+			case 1:
+				// Channel ID
+			case 2:
+				// Lock Status
+				u.Status = v
+			case 3:
+				// US Channel Type
+				u.Modulation = v
+			case 4:
+				// Frequency (Hz)
+				u.Frequency = v
+			case 5:
+				// Width (Hz)
+			case 6:
+				// Power (dBmV)
+				u.PowerLevel = f
+			default:
+				glog.Errorf("Unexpected %dth column in downstream table", i)
+			}
+		}
+		m[ch] = u
+	}
+	return m, nil
+}

--- a/modem/sb8200/sb8200_test.go
+++ b/modem/sb8200/sb8200_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2020 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/modem/sb8200/sb8200_test.go
+++ b/modem/sb8200/sb8200_test.go
@@ -1,0 +1,349 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sb8200
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/wathiede/surfer/modem"
+)
+
+func TestParseStatus(t *testing.T) {
+	flag.Set("v", "true")
+	flag.Set("logtostderr", "true")
+
+	p := "testdata/SB8200.html"
+	r, err := os.Open(p)
+	if err != nil {
+		t.Fatalf("Failed to open %q: %v", p, err)
+	}
+	defer r.Close()
+
+	got, err := parseStatus(r)
+	if err != nil {
+		t.Fatalf("Failed to parse %q: %v", p, err)
+	}
+
+	want := &modem.Signal{
+		Downstream: map[modem.Channel]*modem.Downstream{
+			"29": {
+				Modulation:    "QAM256",
+				Frequency:     "639000000 Hz",
+				PowerLevel:    1.5,
+				SNR:           39.4,
+				Correctable:   1643,
+				Uncorrectable: 3047,
+			},
+			"1": {
+				Modulation:    "QAM256",
+				Frequency:     "459000000 Hz",
+				PowerLevel:    2.4,
+				SNR:           40.1,
+				Correctable:   2549,
+				Uncorrectable: 8191,
+			},
+			"2": {
+				Modulation:    "QAM256",
+				Frequency:     "465000000 Hz",
+				PowerLevel:    2.8,
+				SNR:           40.4,
+				Correctable:   2540,
+				Uncorrectable: 7489,
+			},
+			"3": {
+				Modulation:    "QAM256",
+				Frequency:     "471000000 Hz",
+				PowerLevel:    2.5,
+				SNR:           40.4,
+				Correctable:   2505,
+				Uncorrectable: 7854,
+			},
+			"4": {
+				Modulation:    "QAM256",
+				Frequency:     "477000000 Hz",
+				PowerLevel:    2.6,
+				SNR:           40.5,
+				Correctable:   2343,
+				Uncorrectable: 7456,
+			},
+			"5": {
+				Modulation:    "QAM256",
+				Frequency:     "483000000 Hz",
+				PowerLevel:    2.1,
+				SNR:           40.2,
+				Correctable:   2089,
+				Uncorrectable: 6803,
+			},
+			"6": {
+				Modulation:    "QAM256",
+				Frequency:     "489000000 Hz",
+				PowerLevel:    1.7,
+				SNR:           40.0,
+				Correctable:   2092,
+				Uncorrectable: 6111,
+			},
+			"7": {
+				Modulation:    "QAM256",
+				Frequency:     "495000000 Hz",
+				PowerLevel:    1.6,
+				SNR:           39.9,
+				Correctable:   2220,
+				Uncorrectable: 5516,
+			},
+			"8": {
+				Modulation:    "QAM256",
+				Frequency:     "507000000 Hz",
+				PowerLevel:    0.5,
+				SNR:           39.1,
+				Correctable:   2117,
+				Uncorrectable: 5893,
+			},
+			"9": {
+				Modulation:    "QAM256",
+				Frequency:     "513000000 Hz",
+				PowerLevel:    0.4,
+				SNR:           38.8,
+				Correctable:   2210,
+				Uncorrectable: 5966,
+			},
+			"10": {
+				Modulation:    "QAM256",
+				Frequency:     "519000000 Hz",
+				PowerLevel:    0.5,
+				SNR:           39.4,
+				Correctable:   2145,
+				Uncorrectable: 5962,
+			},
+			"11": {
+				Modulation:    "QAM256",
+				Frequency:     "525000000 Hz",
+				PowerLevel:    0.4,
+				SNR:           39.5,
+				Correctable:   1838,
+				Uncorrectable: 5681,
+			},
+			"12": {
+				Modulation:    "QAM256",
+				Frequency:     "531000000 Hz",
+				PowerLevel:    0.4,
+				SNR:           39.5,
+				Correctable:   1760,
+				Uncorrectable: 5062,
+			},
+			"13": {
+				Modulation:    "QAM256",
+				Frequency:     "543000000 Hz",
+				PowerLevel:    0.2,
+				SNR:           39.5,
+				Correctable:   1711,
+				Uncorrectable: 4013,
+			},
+			"14": {
+				Modulation:    "QAM256",
+				Frequency:     "549000000 Hz",
+				PowerLevel:    -0.3,
+				SNR:           39.0,
+				Correctable:   1797,
+				Uncorrectable: 3586,
+			},
+			"15": {
+				Modulation:    "QAM256",
+				Frequency:     "555000000 Hz",
+				PowerLevel:    -0.1,
+				SNR:           39.1,
+				Correctable:   1961,
+				Uncorrectable: 3673,
+			},
+			"16": {
+				Modulation:    "QAM256",
+				Frequency:     "561000000 Hz",
+				PowerLevel:    -0.3,
+				SNR:           39.0,
+				Correctable:   1760,
+				Uncorrectable: 4294,
+			},
+			"17": {
+				Modulation:    "QAM256",
+				Frequency:     "567000000 Hz",
+				PowerLevel:    -0.1,
+				SNR:           39.0,
+				Correctable:   1739,
+				Uncorrectable: 4569,
+			},
+			"18": {
+				Modulation:    "QAM256",
+				Frequency:     "573000000 Hz",
+				PowerLevel:    0.3,
+				SNR:           39.1,
+				Correctable:   1867,
+				Uncorrectable: 4407,
+			},
+			"19": {
+				Modulation:    "QAM256",
+				Frequency:     "579000000 Hz",
+				PowerLevel:    0.6,
+				SNR:           39.5,
+				Correctable:   1761,
+				Uncorrectable: 4156,
+			},
+			"20": {
+				Modulation:    "QAM256",
+				Frequency:     "585000000 Hz",
+				PowerLevel:    0.6,
+				SNR:           39.4,
+				Correctable:   1700,
+				Uncorrectable: 3700,
+			},
+			"21": {
+				Modulation:    "QAM256",
+				Frequency:     "591000000 Hz",
+				PowerLevel:    0.5,
+				SNR:           39.2,
+				Correctable:   1863,
+				Uncorrectable: 3231,
+			},
+			"22": {
+				Modulation:    "QAM256",
+				Frequency:     "597000000 Hz",
+				PowerLevel:    0.8,
+				SNR:           39.4,
+				Correctable:   1895,
+				Uncorrectable: 2905,
+			},
+			"23": {
+				Modulation:    "QAM256",
+				Frequency:     "603000000 Hz",
+				PowerLevel:    0.6,
+				SNR:           39.0,
+				Correctable:   1836,
+				Uncorrectable: 3035,
+			},
+			"24": {
+				Modulation:    "QAM256",
+				Frequency:     "609000000 Hz",
+				PowerLevel:    0.6,
+				SNR:           39.3,
+				Correctable:   2027,
+				Uncorrectable: 3141,
+			},
+			"25": {
+				Modulation:    "QAM256",
+				Frequency:     "615000000 Hz",
+				PowerLevel:    0.4,
+				SNR:           39.2,
+				Correctable:   1765,
+				Uncorrectable: 3784,
+			},
+			"26": {
+				Modulation:    "QAM256",
+				Frequency:     "621000000 Hz",
+				PowerLevel:    0.8,
+				SNR:           39.2,
+				Correctable:   1928,
+				Uncorrectable: 4098,
+			},
+			"27": {
+				Modulation:    "QAM256",
+				Frequency:     "627000000 Hz",
+				PowerLevel:    0.9,
+				SNR:           39.2,
+				Correctable:   1767,
+				Uncorrectable: 4253,
+			},
+			"28": {
+				Modulation:    "QAM256",
+				Frequency:     "633000000 Hz",
+				PowerLevel:    1.3,
+				SNR:           39.4,
+				Correctable:   1848,
+				Uncorrectable: 4298,
+			},
+			"30": {
+				Modulation:    "QAM256",
+				Frequency:     "645000000 Hz",
+				PowerLevel:    1.4,
+				SNR:           39.3,
+				Correctable:   1521,
+				Uncorrectable: 3600,
+			},
+			"31": {
+				Modulation:    "QAM256",
+				Frequency:     "651000000 Hz",
+				PowerLevel:    1.9,
+				SNR:           39.6,
+				Correctable:   1844,
+				Uncorrectable: 3185,
+			},
+			"32": {
+				Modulation:    "QAM256",
+				Frequency:     "657000000 Hz",
+				PowerLevel:    1.6,
+				SNR:           39.4,
+				Correctable:   1836,
+				Uncorrectable: 3219,
+			},
+			"159": {
+				Modulation:    "Other",
+				Frequency:     "722000000 Hz",
+				PowerLevel:    2.8,
+				SNR:           36.2,
+				Correctable:   1179900627,
+				Uncorrectable: 0,
+			},
+		},
+		Upstream: map[modem.Channel]*modem.Upstream{
+			"1": {
+				Frequency:  "23700000 Hz",
+				PowerLevel: 42.0,
+				Modulation: "SC-QAM Upstream",
+				Status:     "Locked",
+			},
+			"2": {
+				Frequency:  "17300000 Hz",
+				PowerLevel: 42.0,
+				Modulation: "SC-QAM Upstream",
+				Status:     "Locked",
+			},
+			"3": {
+				Frequency:  "30100000 Hz",
+				PowerLevel: 41.0,
+				Modulation: "SC-QAM Upstream",
+				Status:     "Locked",
+			},
+			"4": {
+				Frequency:  "36500000 Hz",
+				PowerLevel: 39.0,
+				Modulation: "SC-QAM Upstream",
+				Status:     "Locked",
+			},
+			"5": {
+				Frequency:  "41200000 Hz",
+				PowerLevel: 41.0,
+				Modulation: "SC-QAM Upstream",
+				Status:     "Locked",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		g, _ := json.MarshalIndent(got, "", "  ")
+		w, _ := json.MarshalIndent(want, "", "  ")
+		t.Errorf("Got:\n%s\nWant:\n%s", g, w)
+	}
+}

--- a/modem/sb8200/testdata/SB8200.html
+++ b/modem/sb8200/testdata/SB8200.html
@@ -1,0 +1,573 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Status</title>
+<script src="jquery-1.7.1.min.js"></script>
+<script src="json2.js"></script>
+<script src="main_arris.js"></script>
+
+<script>
+$(document).ready(function(){
+	$("#htmlheader").load("htmlheader.htm");
+});
+</script>
+</head>
+
+<body>
+<div id="htmlheader"></div>
+	  <!-- Header Area Begin -->
+<div class="header">
+
+<script>
+$(document).ready(function(){
+	$("#pageheaderA").load("pageheaderA.htm");       
+});
+</script>
+
+         <div id="binnacleWrapper1" class="binnacleItems_hide" style="display:none;">
+            <div id="binnacleWrapper2" class="binnacleItems_hide" style="display:none;">
+                <div id="binnacleWrapperLeft"><img src="px1_Ux.png" alt="" class="binnacleWrapperShim"></div>
+                <div id="binnacleWrapperRight"><img src="px1_Ux.png" alt="" class="binnacleWrapperShim"></div>
+                <div id="binnacleWrapperMiddle">
+                    <div id="binnacleInnards">
+                            <div id="binnacleIndicatorWrap"></div>
+                    <div id="binnacleModelName"><span id="thisModelNumberIs">SB8200</span></div>
+                    </div>
+                </div>
+            <!-- end binnacleWrapper1/2 -->
+            </div>
+        </div>
+
+<div id="pageheaderA"></div>
+
+<!--gap--><div id="tmtg"><div class="gap1"><div class="gap2"><div class="gap3"><div class="gap4"></div></div></div></div></div>
+
+                <div id="tmg1"><div id="tmg2"><div id="tmg3"><div id="tmg4"><div id="tmg5"><div id="tmg6">
+
+<div id="topMenu"></div>
+
+<!-- START pageheaderB.htm ADDITIONS -->
+                <!-- end divs for tmg -->
+                </div></div></div></div></div></div>
+
+                <!--gap--><div id="tmbg"><div class="gap1"><div class="gap2"><div class="gap3"><div class="gap4"></div></div></div></div></div>
+
+                <div id="bg1"><div id="bg2"><div id="bg3"><div id="bg4">
+<!-- END pageheaderB.htm ADDITIONS -->
+
+</div> 
+	<!-- End Header -->
+
+	<div class="container">
+		<div class="subHeader">
+			<div class="subHeadcontent">Connection</div>
+		</div>
+	<div class="breadcrumbs"> 
+    	<a href="cmconnectionstatus.html">Status</a>Connection </div>
+
+	<div class="content">
+       	<div class="introText">
+    		<p>The status listed show the connection state of the cable modem. They are used by your service provider to evaluate the operation of the cable modem.</p>
+    	</div>
+
+		
+		<!--form action=/goform/cmconnectionstatus method="post" name="cmconnectionstatus"-->
+<!--% GetRgCfgValue("IpProvMode"); %-->
+<!--% GetRgCfgValue("ApplyRgConnectAction"); %-->
+	
+		
+			<center>
+			<table class="simpleTable">
+        	
+			<tr>
+            	<th colspan="3">Startup Procedure</strong></th>
+            </tr>
+
+			<tr >
+            	<td width="44%" ><strong><u>Procedure</u></strong></td>
+        		<td width="31%" ><strong><u>Status</u></strong></td>
+                <td width="25%" ><strong><u>Comment</u></strong></td>
+			</tr>
+            
+			<tr>
+            	<td>Acquire Downstream Channel</td>
+    			<td>639000000 Hz</td>
+    			<td>Locked</td>
+			</tr>
+            
+			<tr>
+            	<td>Connectivity State</td>
+    			<td>OK</td>
+    			<td>Operational</td>
+			</tr>
+          
+			<tr>
+            	<td>Boot State</td>
+			<td>OK</td>
+    			<td>Operational</td>
+			</tr>
+            
+			<!--% GetRgCfgValue("CmProcedureTable"); %-->
+                        <tr>
+            	<td >Configuration File</td>
+			<td>OK</td>			  
+    			<td><!--%ejGetOther(cmInfo, ConfigurationComment)%--></td>
+			</tr>
+			<tr>
+            	<td >Security</td>
+			<td>Enabled</td>
+    			<td>BPI+</td>
+			</tr>
+             
+			<tr>
+            	<td >DOCSIS Network Access Enabled</td>				                      
+				<td>Allowed</td>
+                                <td></td>
+			</tr>
+		</table>
+        </center>
+        
+        <br clear="all" class="clearfloat">
+		<div class="spacer30"></div>
+
+<center>
+   <table class='simpleTable'>
+<tr><th colspan=8><strong>Downstream Bonded Channels</strong></th></tr>
+      <td><strong>Channel ID</strong></td>
+      <td><strong>Lock Status</strong></td>
+      <td><strong>Modulation</strong></td>
+      <td><strong>Frequency</strong></td>
+      <td><strong>Power</strong></td>
+      <td><strong>SNR/MER</strong></td>
+      <td><strong>Corrected</strong></td>
+      <td><strong>Uncorrectables</strong></td>
+   </tr>
+   <tr align='left'>
+      <td>29</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>639000000 Hz</td>
+      <td>1.5 dBmV</td>
+      <td>39.4 dB</td>
+      <td>1643</td>
+      <td>3047</td>
+   </tr>
+   <tr align='left'>
+      <td>1</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>459000000 Hz</td>
+      <td>2.4 dBmV</td>
+      <td>40.1 dB</td>
+      <td>2549</td>
+      <td>8191</td>
+   </tr>
+   <tr align='left'>
+      <td>2</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>465000000 Hz</td>
+      <td>2.8 dBmV</td>
+      <td>40.4 dB</td>
+      <td>2540</td>
+      <td>7489</td>
+   </tr>
+   <tr align='left'>
+      <td>3</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>471000000 Hz</td>
+      <td>2.5 dBmV</td>
+      <td>40.4 dB</td>
+      <td>2505</td>
+      <td>7854</td>
+   </tr>
+   <tr align='left'>
+      <td>4</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>477000000 Hz</td>
+      <td>2.6 dBmV</td>
+      <td>40.5 dB</td>
+      <td>2343</td>
+      <td>7456</td>
+   </tr>
+   <tr align='left'>
+      <td>5</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>483000000 Hz</td>
+      <td>2.1 dBmV</td>
+      <td>40.2 dB</td>
+      <td>2089</td>
+      <td>6803</td>
+   </tr>
+   <tr align='left'>
+      <td>6</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>489000000 Hz</td>
+      <td>1.7 dBmV</td>
+      <td>40.0 dB</td>
+      <td>2092</td>
+      <td>6111</td>
+   </tr>
+   <tr align='left'>
+      <td>7</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>495000000 Hz</td>
+      <td>1.6 dBmV</td>
+      <td>39.9 dB</td>
+      <td>2220</td>
+      <td>5516</td>
+   </tr>
+   <tr align='left'>
+      <td>8</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>507000000 Hz</td>
+      <td>0.5 dBmV</td>
+      <td>39.1 dB</td>
+      <td>2117</td>
+      <td>5893</td>
+   </tr>
+   <tr align='left'>
+      <td>9</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>513000000 Hz</td>
+      <td>0.4 dBmV</td>
+      <td>38.8 dB</td>
+      <td>2210</td>
+      <td>5966</td>
+   </tr>
+   <tr align='left'>
+      <td>10</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>519000000 Hz</td>
+      <td>0.5 dBmV</td>
+      <td>39.4 dB</td>
+      <td>2145</td>
+      <td>5962</td>
+   </tr>
+   <tr align='left'>
+      <td>11</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>525000000 Hz</td>
+      <td>0.4 dBmV</td>
+      <td>39.5 dB</td>
+      <td>1838</td>
+      <td>5681</td>
+   </tr>
+   <tr align='left'>
+      <td>12</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>531000000 Hz</td>
+      <td>0.4 dBmV</td>
+      <td>39.5 dB</td>
+      <td>1760</td>
+      <td>5062</td>
+   </tr>
+   <tr align='left'>
+      <td>13</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>543000000 Hz</td>
+      <td>0.2 dBmV</td>
+      <td>39.5 dB</td>
+      <td>1711</td>
+      <td>4013</td>
+   </tr>
+   <tr align='left'>
+      <td>14</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>549000000 Hz</td>
+      <td>-0.3 dBmV</td>
+      <td>39.0 dB</td>
+      <td>1797</td>
+      <td>3586</td>
+   </tr>
+   <tr align='left'>
+      <td>15</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>555000000 Hz</td>
+      <td>-0.1 dBmV</td>
+      <td>39.1 dB</td>
+      <td>1961</td>
+      <td>3673</td>
+   </tr>
+   <tr align='left'>
+      <td>16</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>561000000 Hz</td>
+      <td>-0.3 dBmV</td>
+      <td>39.0 dB</td>
+      <td>1760</td>
+      <td>4294</td>
+   </tr>
+   <tr align='left'>
+      <td>17</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>567000000 Hz</td>
+      <td>-0.1 dBmV</td>
+      <td>39.0 dB</td>
+      <td>1739</td>
+      <td>4569</td>
+   </tr>
+   <tr align='left'>
+      <td>18</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>573000000 Hz</td>
+      <td>0.3 dBmV</td>
+      <td>39.1 dB</td>
+      <td>1867</td>
+      <td>4407</td>
+   </tr>
+   <tr align='left'>
+      <td>19</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>579000000 Hz</td>
+      <td>0.6 dBmV</td>
+      <td>39.5 dB</td>
+      <td>1761</td>
+      <td>4156</td>
+   </tr>
+   <tr align='left'>
+      <td>20</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>585000000 Hz</td>
+      <td>0.6 dBmV</td>
+      <td>39.4 dB</td>
+      <td>1700</td>
+      <td>3700</td>
+   </tr>
+   <tr align='left'>
+      <td>21</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>591000000 Hz</td>
+      <td>0.5 dBmV</td>
+      <td>39.2 dB</td>
+      <td>1863</td>
+      <td>3231</td>
+   </tr>
+   <tr align='left'>
+      <td>22</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>597000000 Hz</td>
+      <td>0.8 dBmV</td>
+      <td>39.4 dB</td>
+      <td>1895</td>
+      <td>2905</td>
+   </tr>
+   <tr align='left'>
+      <td>23</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>603000000 Hz</td>
+      <td>0.6 dBmV</td>
+      <td>39.0 dB</td>
+      <td>1836</td>
+      <td>3035</td>
+   </tr>
+   <tr align='left'>
+      <td>24</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>609000000 Hz</td>
+      <td>0.6 dBmV</td>
+      <td>39.3 dB</td>
+      <td>2027</td>
+      <td>3141</td>
+   </tr>
+   <tr align='left'>
+      <td>25</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>615000000 Hz</td>
+      <td>0.4 dBmV</td>
+      <td>39.2 dB</td>
+      <td>1765</td>
+      <td>3784</td>
+   </tr>
+   <tr align='left'>
+      <td>26</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>621000000 Hz</td>
+      <td>0.8 dBmV</td>
+      <td>39.2 dB</td>
+      <td>1928</td>
+      <td>4098</td>
+   </tr>
+   <tr align='left'>
+      <td>27</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>627000000 Hz</td>
+      <td>0.9 dBmV</td>
+      <td>39.2 dB</td>
+      <td>1767</td>
+      <td>4253</td>
+   </tr>
+   <tr align='left'>
+      <td>28</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>633000000 Hz</td>
+      <td>1.3 dBmV</td>
+      <td>39.4 dB</td>
+      <td>1848</td>
+      <td>4298</td>
+   </tr>
+   <tr align='left'>
+      <td>30</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>645000000 Hz</td>
+      <td>1.4 dBmV</td>
+      <td>39.3 dB</td>
+      <td>1521</td>
+      <td>3600</td>
+   </tr>
+   <tr align='left'>
+      <td>31</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>651000000 Hz</td>
+      <td>1.9 dBmV</td>
+      <td>39.6 dB</td>
+      <td>1844</td>
+      <td>3185</td>
+   </tr>
+   <tr align='left'>
+      <td>32</td>
+      <td>Locked</td>
+      <td>QAM256</td>
+      <td>657000000 Hz</td>
+      <td>1.6 dBmV</td>
+      <td>39.4 dB</td>
+      <td>1836</td>
+      <td>3219</td>
+   </tr>
+   <tr align='left'>
+      <td>159</td>
+      <td>Locked</td>
+      <td>Other</td>
+      <td>722000000 Hz</td>
+      <td>2.8 dBmV</td>
+      <td>36.2 dB</td>
+      <td>1179900627</td>
+      <td>0</td>
+   </tr>
+</table><br><br>
+
+</center>
+        
+<br clear="all" class="clearfloat">
+<div class="spacer30"></div>
+
+<center>
+   <table class='simpleTable'>
+<tr><th colspan=7><strong>Upstream Bonded Channels</strong></th></tr>
+      <td><strong>Channel</strong></td>
+      <td><strong>Channel ID</strong></td>
+      <td><strong>Lock Status</strong></td>
+      <td><strong>US Channel Type</td>
+      <td><strong>Frequency</strong></td>
+      <td><strong>Width</strong></td>
+      <td><strong>Power</strong></td>
+   </tr>
+   <tr align='left'>
+      <td>1</td>
+      <td>2</td>
+      <td>Locked</td>
+      <td>SC-QAM Upstream</td>
+      <td>23700000 Hz</td>
+      <td>6400000 Hz</td>
+      <td>42.0 dBmV</td>
+   </tr>
+   <tr align='left'>
+      <td>2</td>
+      <td>1</td>
+      <td>Locked</td>
+      <td>SC-QAM Upstream</td>
+      <td>17300000 Hz</td>
+      <td>6400000 Hz</td>
+      <td>42.0 dBmV</td>
+   </tr>
+   <tr align='left'>
+      <td>3</td>
+      <td>3</td>
+      <td>Locked</td>
+      <td>SC-QAM Upstream</td>
+      <td>30100000 Hz</td>
+      <td>6400000 Hz</td>
+      <td>41.0 dBmV</td>
+   </tr>
+   <tr align='left'>
+      <td>4</td>
+      <td>4</td>
+      <td>Locked</td>
+      <td>SC-QAM Upstream</td>
+      <td>36500000 Hz</td>
+      <td>6400000 Hz</td>
+      <td>39.0 dBmV</td>
+   </tr>
+   <tr align='left'>
+      <td>5</td>
+      <td>5</td>
+      <td>Locked</td>
+      <td>SC-QAM Upstream</td>
+      <td>41200000 Hz</td>
+      <td>1600000 Hz</td>
+      <td>41.0 dBmV</td>
+   </tr>
+</table><br><br>
+
+</center>
+
+<br clear="all" class="clearfloat">
+<div class="spacer30"></div>
+
+<p id="systime" align="center"><strong>Current System Time:</strong> Sat Jun 27 17:10:41 2020
+</p>
+
+</div>
+
+
+<!--/form-->
+
+
+<br clear="all" class="clearfloat">
+<div class="spacer40"></div>
+
+<!-- end .container --></div> 
+
+<!-- Footer and Sitemap -->
+<!-- end divs for bc -->
+</div></div></div></div>	
+<!--gap--><div id="bmtg"><div class="gap1"><div class="gap2"><div class="gap3"><div class="gap4"></div></div></div></div></div>
+   
+<center><div id="siteMapBottom"></div></center>
+<script>
+$(document).ready(function(){
+        $("#footer").load("footer.htm");
+});
+</script>
+<div id="footer"></div>
+
+</body>
+</html>


### PR DESCRIPTION
Fixes #4 

Note that the SB8200 is _not_ the same as the SB6183. Some of the fields in the html tables are different and some are in different column numbers.