### PR TITLE
Add support for self signed certificates

### DIFF
--- a/modem/modem.go
+++ b/modem/modem.go
@@ -16,7 +16,10 @@
 // scrapers will support.
 package modem
 
-import "context"
+import (
+	"context"
+	"net/http"
+)
 
 type Downstream struct {
 	Correctable float64
@@ -55,7 +58,7 @@ type Modem interface {
 	// Fetch the status of the modem using implementation specific means.  The
 	// context.Context passed in can be used to set timeouts or cancel
 	// in-progress requests.
-	Status(context.Context) (*Signal, error)
+	Status(context.Context, http.Client) (*Signal, error)
 }
 
 // NewFunc is registered to determine if a given Modem is available for
@@ -67,7 +70,7 @@ type Modem interface {
 // implementation.
 // Implementations should return nil if path or the default URL do not
 // contain expected results.
-type NewFunc func(ctx context.Context, path string) Modem
+type NewFunc func(ctx context.Context, client http.Client, path string) Modem
 
 var modems []NewFunc
 
@@ -78,10 +81,10 @@ var modems []NewFunc
 // configured URL.  If it is non-empty, the contents of the file should be
 // used to determine if it is a status page for the given Modem
 // implementation.
-func New(ctx context.Context, path string) Modem {
+func New(ctx context.Context, client http.Client, path string) Modem {
 	// TODO(wathiede): run in parallel and take the first that succeeds?
 	for _, f := range modems {
-		m := f(ctx, path)
+		m := f(ctx, client, path)
 		if m != nil {
 			return m
 		}

--- a/modem/sb6183/sb6183.go
+++ b/modem/sb6183/sb6183.go
@@ -45,7 +45,7 @@ func isSB6183(b []byte) bool {
 	return bytes.Contains(b, []byte(`<span id="thisModelNumberIs">SB6183</span>`))
 }
 
-func probe(ctx context.Context, path string) modem.Modem {
+func probe(ctx context.Context, client http.Client, path string) modem.Modem {
 	if path != "" {
 		b, err := ioutil.ReadFile(path)
 		if err != nil {
@@ -63,7 +63,7 @@ func probe(ctx context.Context, path string) modem.Modem {
 		return nil
 	}
 	glog.Infof("Probing %q", signalURL)
-	rc, err := get(ctx)
+	rc, err := get(ctx, client)
 	if err != nil {
 		glog.Errorf("Failed to get status page: %v", err)
 		return nil
@@ -100,13 +100,13 @@ func NewFakeData(path string) (modem.Modem, error) {
 	return &sb6183{fakeData: b}, nil
 }
 
-func get(ctx context.Context) (io.ReadCloser, error) {
+func get(ctx context.Context, client http.Client) (io.ReadCloser, error) {
 	req, err := http.NewRequest("GET", signalURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req = req.WithContext(ctx)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -116,12 +116,12 @@ func get(ctx context.Context) (io.ReadCloser, error) {
 // Status will return signal data parsed from an HTML status page.  If
 // sb.fakeData is not nil, the fake data is parsed.  If it is nil, then an
 // HTTP request is made to the default signal URL of a SB6183.
-func (sb *sb6183) Status(ctx context.Context) (*modem.Signal, error) {
+func (sb *sb6183) Status(ctx context.Context, client http.Client) (*modem.Signal, error) {
 	if sb.fakeData != nil {
 		return parseStatus(bytes.NewReader(sb.fakeData))
 	}
 
-	rc, err := get(ctx)
+	rc, err := get(ctx, client)
 	if err != nil {
 		return nil, err
 	}

--- a/modem/sb8200/sb8200.go
+++ b/modem/sb8200/sb8200.go
@@ -45,7 +45,7 @@ func isSB8200(b []byte) bool {
 	return bytes.Contains(b, []byte(`<span id="thisModelNumberIs">SB8200</span>`))
 }
 
-func probe(ctx context.Context, path string) modem.Modem {
+func probe(ctx context.Context, client http.Client, path string) modem.Modem {
 	if path != "" {
 		b, err := ioutil.ReadFile(path)
 		if err != nil {
@@ -63,7 +63,7 @@ func probe(ctx context.Context, path string) modem.Modem {
 		return nil
 	}
 	glog.Infof("Probing %q", signalURL)
-	rc, err := get(ctx)
+	rc, err := get(ctx, client)
 	if err != nil {
 		glog.Errorf("Failed to get status page: %v", err)
 		return nil
@@ -100,13 +100,13 @@ func NewFakeData(path string) (modem.Modem, error) {
 	return &sb8200{fakeData: b}, nil
 }
 
-func get(ctx context.Context) (io.ReadCloser, error) {
+func get(ctx context.Context, client http.Client) (io.ReadCloser, error) {
 	req, err := http.NewRequest("GET", signalURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req = req.WithContext(ctx)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -116,12 +116,12 @@ func get(ctx context.Context) (io.ReadCloser, error) {
 // Status will return signal data parsed from an HTML status page.  If
 // sb.fakeData is not nil, the fake data is parsed.  If it is nil, then an
 // HTTP request is made to the default signal URL of a SB8200.
-func (sb *sb8200) Status(ctx context.Context) (*modem.Signal, error) {
+func (sb *sb8200) Status(ctx context.Context, client http.Client) (*modem.Signal, error) {
 	if sb.fakeData != nil {
 		return parseStatus(bytes.NewReader(sb.fakeData))
 	}
 
-	rc, err := get(ctx)
+	rc, err := get(ctx, client)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Modify the Modem interface to accept an http.Client. Initialize the basic http.Client with an http.Transport that allows disabling TLS cert checks. The motivation for this is that the SB8200 on Wave uses a self signed cert.